### PR TITLE
Fix exam creation date offset issue

### DIFF
--- a/src/app/(dashboard)/grades/exam-templates/exam-templates-client.tsx
+++ b/src/app/(dashboard)/grades/exam-templates/exam-templates-client.tsx
@@ -259,9 +259,14 @@ export function ExamTemplatesClient() {
     if (!currentUser) return
 
     try {
-      // Calculate next exam date based on recurring schedule
-      const examDate = calculateNextExamDate(template.recurring_schedule)
+      // Use today's date for manual exam creation (not calculateNextExamDate)
+      // recurring_schedule is for automatic recurring generation, not manual creation
+      const examDate = new Date()
       const examName = `${template.name} (${examDate.getFullYear()}.${String(examDate.getMonth() + 1).padStart(2, '0')}.${String(examDate.getDate()).padStart(2, '0')})`
+
+      // Format date for database (YYYY-MM-DD) without timezone issues
+      // Do NOT use toISOString() as it converts to UTC and can change the date
+      const examDateStr = `${examDate.getFullYear()}-${String(examDate.getMonth() + 1).padStart(2, '0')}-${String(examDate.getDate()).padStart(2, '0')}`
 
       const newExam = {
         tenant_id: currentUser.tenantId,
@@ -273,7 +278,7 @@ export function ExamTemplatesClient() {
         passing_score: template.passing_score,
         class_id: template.class_id,
         description: template.description,
-        exam_date: examDate.toISOString().split('T')[0],
+        exam_date: examDateStr,
         is_recurring: false,
       }
 


### PR DESCRIPTION
템플릿으로 시험을 생성할 때 날짜가 +7일로 잘못 생성되던 문제를 해결했습니다.

변경 사항:
- 수동 생성 시 오늘 날짜 사용 (calculateNextExamDate 함수 호출 제거)
- recurring_schedule은 자동 반복 생성을 위한 설정으로, 수동 생성 시에는 사용하지 않음
- 타임존 이슈 해결: toISOString() 대신 로컬 날짜 포맷팅 사용
- UTC 변환 없이 YYYY-MM-DD 형식으로 날짜 생성하여 한국 시간(UTC+9) 오프셋 문제 방지

기술적 개선:
- Date 객체를 직접 포맷팅하여 타임존 변환 없이 정확한 날짜 저장
- 주석 추가로 향후 유지보수성 향상