### PR TITLE
Fix exam information editing error

### DIFF
--- a/src/app/(dashboard)/grades/exams/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/grades/exams/[id]/edit/page.tsx
@@ -35,7 +35,7 @@ export default async function EditExamPage({ params }: PageProps) {
     subject_id: exam.subject_id || undefined,
     category_code: exam.category_code || undefined,
     exam_type: exam.exam_type || undefined,
-    exam_date: exam.exam_date || '',
+    exam_date: exam.exam_date || undefined,
     class_id: exam.class_id || undefined,
     total_questions: exam.total_questions?.toString() || '',
     passing_score: exam.passing_score?.toString() || '',

--- a/src/components/features/exams/ExamForm.tsx
+++ b/src/components/features/exams/ExamForm.tsx
@@ -489,7 +489,10 @@ export function ExamForm({ mode, examId, defaultValues, onSuccess }: ExamFormPro
                 name="exam_date"
                 render={({ field }) => {
                   // Convert string (YYYY-MM-DD) to Date for DatePicker
-                  const dateValue = field.value ? parse(field.value, 'yyyy-MM-dd', new Date()) : undefined
+                  // Handle empty strings safely
+                  const dateValue = field.value && field.value.trim() !== ''
+                    ? parse(field.value, 'yyyy-MM-dd', new Date())
+                    : undefined
 
                   return (
                     <FormItem>


### PR DESCRIPTION
- exam_date가 빈 문자열일 때 parse 함수에서 Invalid Date 발생하는 문제 해결
- edit/page.tsx: exam_date 기본값을 빈 문자열에서 undefined로 변경
- ExamForm.tsx: parse 전에 빈 문자열 체크 로직 추가하여 방어적 처리