### PR TITLE
feat(hooks): React Query 기반 훅 리팩토링

### DIFF
--- a/src/hooks/use-current-user.ts
+++ b/src/hooks/use-current-user.ts
@@ -4,13 +4,18 @@
  * Client-side hook to get current authenticated user information
  * Uses Supabase client (with RLS) for safe client-side queries
  *
+ * ✅ React Query 기반으로 리팩토링됨:
+ * - 자동 캐싱 (5분)
+ * - 백그라운드 refetch
+ * - 에러 재시도
+ *
  * @example
  * const { user, tenant, isLoading, error } = useCurrentUser()
  */
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { createClient } from '@/lib/supabase/client'
 
 export interface CurrentUser {
@@ -31,74 +36,73 @@ export interface UseCurrentUserReturn {
   refetch: () => Promise<void>
 }
 
-export function useCurrentUser(): UseCurrentUserReturn {
-  const [user, setUser] = useState<CurrentUser | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
+/**
+ * Query key for current user
+ */
+export const CURRENT_USER_QUERY_KEY = ['currentUser']
 
-  const fetchUser = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
+/**
+ * Fetch current user from Supabase
+ */
+async function fetchCurrentUser(): Promise<CurrentUser | null> {
+  const supabase = createClient()
 
-      const supabase = createClient()
+  // 1. Get authenticated user
+  const {
+    data: { user: authUser },
+    error: authError,
+  } = await supabase.auth.getUser()
 
-      // 1. Get authenticated user
-      const {
-        data: { user: authUser },
-        error: authError,
-      } = await supabase.auth.getUser()
-
-      if (authError || !authUser) {
-        setUser(null)
-        setIsLoading(false)
-        return
-      }
-
-      // 2. Get user profile
-      const { data: userData, error: userError } = await supabase
-        .from('users')
-        .select('id, email, name, tenant_id, role_code, approval_status, onboarding_completed')
-        .eq('id', authUser.id)
-        .maybeSingle()
-
-      if (userError) {
-        throw userError
-      }
-
-      if (!userData) {
-        setUser(null)
-        setIsLoading(false)
-        return
-      }
-
-      setUser({
-        id: userData.id,
-        email: userData.email,
-        name: userData.name,
-        tenantId: userData.tenant_id || '',
-        roleCode: userData.role_code || '',
-        approvalStatus: userData.approval_status,
-        onboardingCompleted: userData.onboarding_completed,
-      })
-    } catch (err) {
-      console.error('[useCurrentUser] Error:', err)
-      setError(err instanceof Error ? err : new Error('Failed to fetch user'))
-      setUser(null)
-    } finally {
-      setIsLoading(false)
-    }
+  if (authError || !authUser) {
+    return null
   }
 
-  useEffect(() => {
-    fetchUser()
-  }, [])
+  // 2. Get user profile
+  const { data: userData, error: userError } = await supabase
+    .from('users')
+    .select('id, email, name, tenant_id, role_code, approval_status, onboarding_completed')
+    .eq('id', authUser.id)
+    .maybeSingle()
+
+  if (userError) {
+    throw userError
+  }
+
+  if (!userData) {
+    return null
+  }
 
   return {
-    user,
+    id: userData.id,
+    email: userData.email,
+    name: userData.name,
+    tenantId: userData.tenant_id || '',
+    roleCode: userData.role_code || '',
+    approvalStatus: userData.approval_status,
+    onboardingCompleted: userData.onboarding_completed,
+  }
+}
+
+export function useCurrentUser(): UseCurrentUserReturn {
+  const {
+    data: user,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: CURRENT_USER_QUERY_KEY,
+    queryFn: fetchCurrentUser,
+    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+    gcTime: 30 * 60 * 1000,   // 30분간 가비지 컬렉션 대기
+    refetchOnWindowFocus: true,
+    retry: 1,
+  })
+
+  return {
+    user: user ?? null,
     isLoading,
     loading: isLoading,  // Alias for backward compatibility
-    error,
-    refetch: fetchUser,
+    error: error as Error | null,
+    refetch: async () => { await refetch() },
   }
 }

--- a/src/hooks/use-dashboard-data.ts
+++ b/src/hooks/use-dashboard-data.ts
@@ -2,12 +2,18 @@
  * useDashboardData Hook
  *
  * Fetches dashboard data using Server Actions
- * TODO: Replace old RPC-based approach with Server Actions
+ *
+ * ✅ React Query 기반으로 리팩토링됨:
+ * - 자동 캐싱 (1분)
+ * - 백그라운드 refetch
+ * - 에러 재시도
+ *
+ * TODO: Server Action 연동 후 실제 데이터 반환으로 변경
  */
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 
 // Re-export types from core for convenience
 export type {
@@ -59,62 +65,74 @@ export interface UseDashboardDataReturn {
   refetch: () => Promise<void>
 }
 
+/**
+ * Query key for dashboard data
+ */
+export const DASHBOARD_DATA_QUERY_KEY = ['dashboardData']
+
+/**
+ * Default empty dashboard data
+ */
+const EMPTY_DASHBOARD_DATA: DashboardDataCompat = {
+  stats: {
+    totalStudents: 0,
+    activeClasses: 0,
+    todayAttendance: 0,
+    pendingTodos: 0,
+  },
+  recentStudents: [],
+  todaySessions: [],
+  birthdayStudents: [],
+  scheduledConsultations: [],
+  studentAlerts: {
+    longAbsence: [],
+    pendingAssignments: [],
+  },
+  financialData: {
+    currentMonthRevenue: 0,
+    previousMonthRevenue: 0,
+    unpaidTotal: 0,
+    unpaidCount: 0,
+  },
+  classStatus: [],
+  parentsToContact: [],
+  calendarEvents: [],
+  activityLogs: [],
+}
+
+/**
+ * Fetch dashboard data from Server Action
+ */
+async function fetchDashboardData(): Promise<DashboardDataCompat> {
+  // TODO: Call Server Action instead of returning mock data
+  // const result = await getDashboardData()
+  // if (!result.success) throw new Error(result.error)
+  // return result.data
+
+  // For now, return empty data (placeholder)
+  return EMPTY_DASHBOARD_DATA
+}
+
 export function useDashboardData(): UseDashboardDataReturn {
-  const [data, setData] = useState<DashboardDataCompat | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
-
-  const fetchData = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-
-      // TODO: Call Server Action instead of RPC
-      // const result = await getDashboardData()
-
-      // For now, return mock data
-      setData({
-        stats: {
-          totalStudents: 0,
-          activeClasses: 0,
-          todayAttendance: 0,
-          pendingTodos: 0,
-        },
-        recentStudents: [],
-        todaySessions: [],
-        birthdayStudents: [],
-        scheduledConsultations: [],
-        studentAlerts: {
-          longAbsence: [],
-          pendingAssignments: [],
-        },
-        financialData: {
-          currentMonthRevenue: 0,
-          previousMonthRevenue: 0,
-          unpaidTotal: 0,
-          unpaidCount: 0,
-        },
-        classStatus: [],
-        parentsToContact: [],
-        calendarEvents: [],
-        activityLogs: [],
-      })
-    } catch (err) {
-      console.error('[useDashboardData] Error:', err)
-      setError(err instanceof Error ? err : new Error('Failed to fetch dashboard data'))
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    fetchData()
-  }, [])
-
-  return {
+  const {
     data,
     isLoading,
     error,
-    refetch: fetchData,
+    refetch,
+  } = useQuery({
+    queryKey: DASHBOARD_DATA_QUERY_KEY,
+    queryFn: fetchDashboardData,
+    staleTime: 60 * 1000,       // 1분간 캐시 유지
+    gcTime: 5 * 60 * 1000,      // 5분간 가비지 컬렉션 대기
+    refetchOnWindowFocus: true, // 창 포커스 시 자동 refetch
+    refetchInterval: 5 * 60 * 1000, // 5분마다 자동 refetch
+    retry: 1,
+  })
+
+  return {
+    data: data ?? null,
+    isLoading,
+    error: error as Error | null,
+    refetch: async () => { await refetch() },
   }
 }


### PR DESCRIPTION
## Summary
- `use-current-user.ts`: React Query `useQuery` 적용
  - staleTime: 5분간 캐시 유지
  - gcTime: 30분간 가비지 컬렉션 대기
  - refetchOnWindowFocus: true
- `use-dashboard-data.ts`: React Query `useQuery` 적용
  - staleTime: 1분간 캐시 유지
  - gcTime: 5분간 가비지 컬렉션 대기
  - refetchInterval: 5분마다 자동 refetch

## Changes
- 자동 캐싱으로 불필요한 API 호출 감소
- 백그라운드 refetch로 최신 데이터 유지
- 에러 재시도 로직 추가 (retry: 1)

## Test plan
- [ ] 로그인 후 대시보드 접속
- [ ] useCurrentUser 캐싱 동작 확인 (5분간 재호출 없음)
- [ ] useDashboardData 자동 refetch 확인 (5분마다)
- [ ] 창 포커스 시 데이터 갱신 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)