### PR TITLE
refactor: 비활성화된 PDF 기능 코드 제거로 번들 크기 최적화

### DIFF
--- a/src/app/(dashboard)/reports/[id]/page.tsx
+++ b/src/app/(dashboard)/reports/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { usePDF } from '@react-pdf/renderer'
 import { createClient } from '@/lib/supabase/client'
 import { Button } from '@ui/button'
 import { Badge } from '@ui/badge'
@@ -26,13 +25,12 @@ import {
 } from '@ui/dialog'
 import { Textarea } from '@ui/textarea'
 import { Label } from '@ui/label'
-import { Download, Send, Edit2, CheckCircle, XCircle, Clock, MessageSquare } from 'lucide-react'
+import { Send, Edit2, CheckCircle, XCircle, Clock, MessageSquare } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { PageWrapper } from "@/components/layout/page-wrapper"
 import type { ReportWithStudent } from '@/core/types/report.types'
 import type { CategoryTemplates, ReportContextData } from '@/core/types/report-template.types'
 import { ReportViewer } from '@/components/features/reports/ReportViewer'
-import { ReportPdfDocument } from '@/components/features/reports/ReportPdfDocument'
 import { TemplateSection } from '@/components/features/reports/template-section'
 import { FEATURES } from '@/lib/features.config'
 import { ComingSoon } from '@/components/layout/coming-soon'
@@ -71,35 +69,8 @@ export default function ReportDetailPage({ params }: { params: { id: string } })
   const supabase = createClient()
   const contentRef = useRef<HTMLDivElement>(null)
 
-  // PDF generation with usePDF hook
-  // Only initialize PDF when report is available
-  const [instance, updatePdf] = usePDF({
-    document: <></>,
-  })
-
-  // Update PDF when report data changes
-  useEffect(() => {
-    if (report) {
-      try {
-        const pdfDocument = (
-          <ReportPdfDocument
-            reportData={report.content}
-            studentName={report.students?.users?.name || report.content.studentName || report.content.student?.name || '학생'}
-            studentCode={report.students?.student_code || report.content.studentCode || report.content.student?.student_code || ''}
-            studentGrade={report.students?.grade || report.content.grade || report.content.student?.grade || ''}
-            periodStart={report.period_start}
-            periodEnd={report.period_end}
-            generatedAt={report.generated_at}
-          />
-        )
-        updatePdf(pdfDocument)
-      } catch (error) {
-        console.error('PDF update error:', error)
-        // Silently fail PDF updates to avoid crashing the UI
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [report])
+  // NOTE: PDF generation removed - see ReportPdfDocument.tsx if needed
+  // PDF download feature is disabled, so usePDF hook removed to save ~400KB bundle
 
   useEffect(() => {
     loadReport()
@@ -314,53 +285,6 @@ export default function ReportDetailPage({ params }: { params: { id: string } })
     return types[type] || type
   }
 
-  // PDF download handler
-  function handlePdfDownload() {
-    if (instance.loading) {
-      toast({
-        title: 'PDF 생성 중',
-        description: 'PDF를 생성하는 중입니다. 잠시만 기다려주세요.',
-      })
-      return
-    }
-
-    if (!instance.blob) {
-      toast({
-        title: 'PDF 생성 실패',
-        description: 'PDF를 생성할 수 없습니다. 페이지를 새로고침한 후 다시 시도해주세요.',
-        variant: 'destructive',
-      })
-      return
-    }
-
-    if (!report) return
-
-    try {
-      // Create anchor tag to trigger download
-      const link = document.createElement('a')
-      link.href = URL.createObjectURL(instance.blob)
-      const studentName = report.students?.users?.name || report.content.studentName || report.content.student?.name || '학생'
-      const fileName = `${studentName}_${new Date(report.period_start).getFullYear()}년_${new Date(report.period_start).getMonth() + 1}월_리포트.pdf`
-      link.download = fileName
-      document.body.appendChild(link)
-      link.click()
-      document.body.removeChild(link)
-      URL.revokeObjectURL(link.href)
-
-      toast({
-        title: 'PDF 다운로드 완료',
-        description: `${studentName} 학생의 리포트가 다운로드되었습니다.`,
-      })
-    } catch (error) {
-      console.error('PDF download error:', error)
-      toast({
-        title: '다운로드 실패',
-        description: 'PDF 다운로드 중 오류가 발생했습니다.',
-        variant: 'destructive',
-      })
-    }
-  }
-
   // Feature flag checks after all Hooks
   const featureStatus = FEATURES.reportManagement;
 
@@ -420,15 +344,6 @@ export default function ReportDetailPage({ params }: { params: { id: string } })
             </p>
           </div>
           <div className="flex gap-2 print:hidden">
-            {/* PDF 다운로드 버튼 임시 숨김 */}
-            {/* <Button
-              variant="outline"
-              onClick={handlePdfDownload}
-              disabled={instance.loading && !instance.blob}
-            >
-              <Download className="h-4 w-4 mr-2" />
-              {instance.loading && !instance.blob ? 'PDF 준비 중...' : 'PDF 다운로드'}
-            </Button> */}
             {!report.sent_at && (
               <Button onClick={handleSendClick} disabled={sending}>
                 <Send className="h-4 w-4 mr-2" />

--- a/src/components/features/reports/ReportShareViewer.tsx
+++ b/src/components/features/reports/ReportShareViewer.tsx
@@ -1,13 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
-import { usePDF } from '@react-pdf/renderer'
-import { Button } from '@ui/button'
 import { Card, CardContent } from '@ui/card'
-import { Download } from 'lucide-react'
-import { useToast } from '@/hooks/use-toast'
 import { ReportViewer } from './ReportViewer'
-import { ReportPdfDocument } from './ReportPdfDocument'
 import type { ReportData } from '@/core/types/report.types'
 
 interface ReportShareViewerProps {
@@ -23,57 +17,11 @@ interface ReportShareViewerProps {
   academyName: string
 }
 
+// NOTE: PDF generation removed - see ReportPdfDocument.tsx if needed
+// PDF download feature is disabled, so usePDF hook removed to save ~400KB bundle
+
 export function ReportShareViewer(props: ReportShareViewerProps) {
-  const { toast } = useToast()
   const currentYear = new Date().getFullYear()
-
-  const [instance, updatePdf] = usePDF({
-    document: (
-      <ReportPdfDocument
-        reportData={props.reportData}
-        studentName={props.studentName}
-        studentCode={props.studentCode}
-        studentGrade={props.studentGrade}
-        periodStart={props.periodStart}
-        periodEnd={props.periodEnd}
-        generatedAt={props.generatedAt}
-      />
-    ),
-  })
-
-  useEffect(() => {
-    updatePdf(
-      <ReportPdfDocument
-        reportData={props.reportData}
-        studentName={props.studentName}
-        studentCode={props.studentCode}
-        studentGrade={props.studentGrade}
-        periodStart={props.periodStart}
-        periodEnd={props.periodEnd}
-        generatedAt={props.generatedAt}
-      />
-    )
-  }, [updatePdf, props])
-
-  function handlePdfDownload() {
-    if (!instance.blob || instance.loading) return
-
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(instance.blob)
-    const year = new Date(props.periodStart).getFullYear()
-    const month = new Date(props.periodStart).getMonth() + 1
-    const fileName = `${props.studentName}_${year}년_${month}월_리포트.pdf`
-    link.download = fileName
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(link.href)
-
-    toast({
-      title: 'PDF 다운로드 완료',
-      description: `${props.studentName} 학생의 리포트가 다운로드되었습니다.`,
-    })
-  }
 
   const viewerData = {
     ...props.reportData,
@@ -105,19 +53,6 @@ export function ReportShareViewer(props: ReportShareViewerProps) {
           <h1 className="text-2xl sm:text-3xl font-bold text-primary">월간 리포트</h1>
           <p className="text-sm text-muted-foreground">{periodStartFormatted} ~ {periodEndFormatted}</p>
         </div>
-
-        {/* PDF 다운로드 기능 임시 비활성화 */}
-        {/* <div className="flex justify-end print:hidden">
-          <Button
-            variant="outline"
-            onClick={handlePdfDownload}
-            disabled={instance.loading || !instance.blob}
-            className="gap-2"
-          >
-            <Download className="h-4 w-4" />
-            {instance.loading ? 'PDF 생성 중...' : 'PDF 다운로드'}
-          </Button>
-        </div> */}
 
         <ReportViewer
           reportData={viewerData}


### PR DESCRIPTION
## Summary
- 비활성화된 PDF 다운로드 기능의 코드를 제거하여 번들 크기 최적화
- `@react-pdf/renderer` (~400KB)가 불필요하게 로드되는 문제 해결

## Changes

### `src/app/(dashboard)/reports/[id]/page.tsx`
- `usePDF` 훅 및 관련 import 제거
- `ReportPdfDocument` import 제거
- `handlePdfDownload` 함수 제거
- 주석 처리된 PDF 다운로드 버튼 제거

### `src/components/features/reports/ReportShareViewer.tsx`
- `usePDF` 훅 및 관련 import 제거
- `useEffect` (PDF 업데이트) 제거
- `handlePdfDownload` 함수 제거
- 불필요한 `useToast` import 제거

## Notes
- PDF 다운로드 기능 재활성화 시 `dynamic import`로 구현 권장
- `ReportPdfDocument.tsx`는 유지 (나중에 필요할 수 있음)

## Test plan
- [ ] 리포트 상세 페이지 정상 동작 확인
- [ ] 리포트 공유 뷰어 정상 동작 확인
- [ ] 빌드 성공 확인

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)